### PR TITLE
add mi file to the list of supported files

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"languages": [{
 			"id": "mason",
 			"aliases": ["HTML (Mason)", "mason"],
-			"extensions": [".mhtml",".autohandler",".dhandler",".md",".mc"],
+			"extensions": [".mhtml",".autohandler",".dhandler",".md",".mc",".mi"],
 			"configuration": "./mason.configuration.json"
 		}],
 		"grammars": [{


### PR DESCRIPTION
mi is a mason internal component - https://metacpan.org/pod/Mason%3a%3aManual%3a%3aComponents#Component-file-extensions