### PR TITLE
Case insensitivity for the special tags (e.g., perl, init...)

### DIFF
--- a/syntaxes/html-mason.tmLanguage
+++ b/syntaxes/html-mason.tmLanguage
@@ -20,7 +20,7 @@
 	<array>
 		<dict>
 			<key>begin</key>
-			<string>(&lt;%(perl|attr|global|once|init|cleanup|requestlocal|requestonce|shared|threadlocal|threadonce|flags)( scope.*?)?&gt;)</string>
+			<string>(&lt;%(?i:(perl|attr|global|once|init|cleanup|requestlocal|requestonce|shared|threadlocal|threadonce|flags))( scope.*?)?&gt;)</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
I've been having issues opening certain Mason files due to the case-insensitivity of the special tags (see [https://github.com/bestpractical/rt/blob/stable/share/html/Admin/Tools/Configuration.html](https://github.com/bestpractical/rt/blob/stable/share/html/Admin/Tools/Configuration.html) for an example that combines both lowercase `%init` and uppercase `%PERL`)

This pull request modifies slightly the syntax to support any casing.

It is also possible that other tags (e.g., `%args`) or even any `%tag` should be supported as well.